### PR TITLE
Set right default value for maxIterations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,28 @@
+sudo: false
+
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7
-  - hhvm
+cache:
+  apt: true
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
+    - php: hhvm-3.18
+      sudo: required
+      dist: trusty
+      group: edge
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: nightly
+  fast_finish: true
+  allow_failures:
+    - php: nightly
 
 before_script:
   - composer install

--- a/src/Simpleue/Worker/QueueWorker.php
+++ b/src/Simpleue/Worker/QueueWorker.php
@@ -17,7 +17,7 @@ class QueueWorker
     protected $maxIterations;
     protected $logger;
 
-    public function __construct(Queue $queueHandler, Job $jobHandler, $maxIterations = false)
+    public function __construct(Queue $queueHandler, Job $jobHandler, $maxIterations = 0)
     {
         $this->queueHandler = $queueHandler;
         $this->jobHandler = $jobHandler;


### PR DESCRIPTION
Defining the default value of `$maxIterations` to be `false` define the variable as boolean by "default".

Since the variable is then casted as an integer and [`(int) false === 0`](https://3v4l.org/pQC2n) I think it preferable to define the default value at `0` so it tells that the variable should be an integer