### PR TITLE
Handle some signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The worker is also capable for handling some posix signals, *viz.* `SIGINT` and 
 This behaviour is disabled by default. To enable it, you need to pass an extra parameter
 in the constructor of the worker class. See Usage below for an example.
 
+**Note: This feature is not tested in HHVM, thus might not work as expected if you are running
+it on HHVM**
+
 Queue
 -----
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ The loop can be **stopped** under control using the following methods:
 Each worker has one queue source and manage one type of jobs. Many workers
 can be working concurrently using the same queue source.
 
+### Graceful Exit
+
+The worker is also capable for handling some posix signals, *viz.* `SIGINT` and `SIGTERM` so
+ that it exits gracefully (waits for the current queue job to complete) when someone tries to
+ manually stop it (usually with a `C-c` keystroke in a shell).
+ 
+This behaviour is disabled by default. To enable it, you need to pass an extra parameter
+in the constructor of the worker class. See Usage below for an example.
+
 Queue
 -----
 
@@ -186,6 +195,32 @@ $beanStalkdQueue = new BeanStalkdQueue($beanStalkdClient, 'my_queue_name');
 
 $myNewConsumer = new QueueWorker($beanStalkdQueue, new MyJob());
 $myNewConsumer->start();
+```
+
+**Using maxIterations**
+
+There are two ways you can set maximum iterations, both are shown below:
+
+Using Setter Method
+```php
+$myConsumer = new QueueWorker($myQueue, new MyJob());
+$myConsumer->setMaxIterations(10); //any number
+$myConsumer->start();
+```
+
+Using Constructor Parameter
+```php
+$myConsumer = new QueueWorker($myQueue, new MyJob(), 10);
+$myConsumer->start();
+```
+
+**Enabling Graceful Exit**
+
+To enable graceful exit, pass in an extra parameter in the constructor.
+
+```php
+$myConsumer = new QueueWorker($myQueue, new MyJob(), 10, true);
+$myConsumer->start();
 ```
 
 (*) The idea is to support any queue system, so it is open for that. Contributions are welcome.

--- a/tests/Simpleue/Mocks/JobSpy.php
+++ b/tests/Simpleue/Mocks/JobSpy.php
@@ -11,12 +11,18 @@ use Simpleue\Job\Job;
 class JobSpy implements Job {
 
     private $manageCounter;
+    private $quitCount;
+    private $testSignal;
 
     public function _construct() {
         $this->manageCounter = 0;
     }
 
     public function manage($job) {
+        if ($this->quitCount && (($this->manageCounter+1) === $this->quitCount)) {
+            posix_kill(posix_getpid(), $this->testSignal);
+        }
+
         $this->manageCounter++;
         return true;
     }
@@ -25,4 +31,15 @@ class JobSpy implements Job {
         return ($job === 'STOP');
     }
 
+    public function setQuitCount($num) {
+        $this->quitCount = $num;
+    }
+
+    public function setSignalToTest($sig) {
+        $this->testSignal = $sig;
+    }
+
+    public function getManageCounter() {
+        return $this->manageCounter;
+    }
 }

--- a/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
+++ b/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
@@ -164,6 +164,32 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(8, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
+    public function testWorkerExitsGracefullyOnSigINT() {
+        if (!function_exists('pcntl_signal')) {
+            $this->markTestSkipped('Enable pcntl_* extension to run this test');
+        }
+
+        $this->jobHandlerMock->setQuitCount(3);
+        $this->jobHandlerMock->setSignalToTest(SIGINT);
+        $this->queueWorkerSpy = new QueueWorkerSpy($this->sourceQueueMock, $this->jobHandlerMock, 10, true);
+        $this->queueWorkerSpy->start();
+        $this->assertEquals(3, $this->queueWorkerSpy->getIterations());
+        $this->assertEquals(3, $this->jobHandlerMock->getmanageCounter());
+    }
+
+    public function testWorkerExitsGracefullyOnSigTERM() {
+        if (!function_exists('pcntl_signal')) {
+            $this->markTestSkipped('Enable pcntl_* extension to run this test');
+        }
+
+        $this->jobHandlerMock->setQuitCount(8);
+        $this->jobHandlerMock->setSignalToTest(SIGTERM);
+        $this->queueWorkerSpy = new QueueWorkerSpy($this->sourceQueueMock, $this->jobHandlerMock, 10, true);
+        $this->queueWorkerSpy->start();
+        $this->assertEquals(8, $this->queueWorkerSpy->getIterations());
+        $this->assertEquals(8, $this->jobHandlerMock->getmanageCounter());
+    }
+
     public function testLoggerDebug() {
         $loggerSpy = new LoggerSpy();
         $this->queueWorkerSpy->setMaxIterations(1);

--- a/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
+++ b/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
@@ -169,6 +169,10 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('Enable pcntl_* extension to run this test');
         }
 
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('The Graceful Exit feature does not work for HHVM');
+        }
+
         $this->jobHandlerMock->setQuitCount(3);
         $this->jobHandlerMock->setSignalToTest(SIGINT);
         $this->queueWorkerSpy = new QueueWorkerSpy($this->sourceQueueMock, $this->jobHandlerMock, 10, true);
@@ -180,6 +184,10 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
     public function testWorkerExitsGracefullyOnSigTERM() {
         if (!function_exists('pcntl_signal')) {
             $this->markTestSkipped('Enable pcntl_* extension to run this test');
+        }
+
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('The Graceful Exit feature does not work for HHVM');
         }
 
         $this->jobHandlerMock->setQuitCount(8);


### PR DESCRIPTION
When you provide SIGTERM or SIGINT(`C-c`) in a php cli, the default behavior makes the process quit without caring to complete the current job. 

By catching those signals, we could ensure that the console exits gracefully.  