### PR TITLE
Added isMyJob method to job handler interface - BC Break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 composer.lock
+composer.phar
 vendor/
 logs/

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ The job interface is used to manage the job received in the queue. It must manag
 business logic and **define the STOP job**.
 
 The job is abstracted form the queue system, so the same job definition is able to work with
-different queues interfaces. The job always receive the message body from the queue,
+different queues interfaces. The job always receive the message body from the queue.
+
+If you have different job types ( send mail, crop images, etc. ) and you use one queue, you can define **isMyJob**. 
+If job is not expected type, you can send back job to queue.
 
 Install
 -------
@@ -135,6 +138,11 @@ class MyJob implements Job {
         return FALSE;
     }
     
+    public function isMyJob($job) {
+            if ( ... )
+                return TRUE;
+            return FALSE;
+    }
     ...
 
 }

--- a/src/Simpleue/Job/Job.php
+++ b/src/Simpleue/Job/Job.php
@@ -10,4 +10,5 @@ namespace Simpleue\Job;
 interface Job {
     public function manage($job);
     public function isStopJob($job);
+    public function isValidJob($job);
 }

--- a/src/Simpleue/Job/Job.php
+++ b/src/Simpleue/Job/Job.php
@@ -10,5 +10,5 @@ namespace Simpleue\Job;
 interface Job {
     public function manage($job);
     public function isStopJob($job);
-    public function isValidJob($job);
+    public function isMyJob($job);
 }

--- a/src/Simpleue/Worker/QueueWorker.php
+++ b/src/Simpleue/Worker/QueueWorker.php
@@ -74,7 +74,7 @@ class QueueWorker
                 $this->queueHandler->error(false, $exception);
                 continue;
             }
-            if ($this->isValidJob($job)) {
+            if ($this->isValidJob($job) && $this->jobHandler->isMyJob($this->queueHandler->getMessageBody($job))) {
                 if ($this->jobHandler->isStopJob($this->queueHandler->getMessageBody($job))) {
                     $this->queueHandler->stopped($job);
                     $this->log('debug', 'STOP instruction received.');
@@ -117,7 +117,7 @@ class QueueWorker
 
     protected function isValidJob($job)
     {
-        return $job !== false && $this->jobHandler->isValidJob($job);
+        return $job !== false;
     }
 
     protected function handleSignals()

--- a/src/Simpleue/Worker/QueueWorker.php
+++ b/src/Simpleue/Worker/QueueWorker.php
@@ -117,7 +117,7 @@ class QueueWorker
 
     protected function isValidJob($job)
     {
-        return $job !== false;
+        return $job !== false && $this->jobHandler->isValidJob($job);
     }
 
     protected function handleSignals()

--- a/tests/Simpleue/Mocks/JobSpy.php
+++ b/tests/Simpleue/Mocks/JobSpy.php
@@ -31,6 +31,10 @@ class JobSpy implements Job {
         return ($job === 'STOP');
     }
 
+    public function isValidJob($job) {
+        return ($job !== false);
+    }
+
     public function setQuitCount($num) {
         $this->quitCount = $num;
     }

--- a/tests/Simpleue/Mocks/JobSpy.php
+++ b/tests/Simpleue/Mocks/JobSpy.php
@@ -31,7 +31,7 @@ class JobSpy implements Job {
         return ($job === 'STOP');
     }
 
-    public function isValidJob($job) {
+    public function isMyJob($job) {
         return ($job !== false);
     }
 

--- a/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
+++ b/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
@@ -89,7 +89,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(3, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(6, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(4, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testRunManagedFailedJobs() {

--- a/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
+++ b/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
@@ -77,8 +77,6 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->jobHandlerMock->expects($this->at(0))->method('isValidJob')->willReturn(true);
         $this->jobHandlerMock->expects($this->at(1))->method('isValidJob')->willReturn(false);
         $this->jobHandlerMock->expects($this->at(2))->method('isValidJob')->willReturn(true);
-        $this->jobHandlerMock->expects($this->at(3))->method('isValidJob')->willReturn(true);
-        $this->jobHandlerMock->expects($this->at(4))->method('isValidJob')->willReturn(true);
 
         $this->queueWorkerSpy = new QueueWorkerSpy($this->sourceQueueMock, $this->jobHandlerMock);
         $this->queueWorkerSpy->setMaxIterations(5);

--- a/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
+++ b/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
@@ -73,14 +73,21 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->sourceQueueMock->expects($this->at(3))->method('getNext')->willReturn(0);
         $this->sourceQueueMock->expects($this->at(4))->method('getNext')->willReturn('');
 
+        $this->jobHandlerMock = $this->getMock('Simpleue\Mocks\JobSpy', array('isValidJob'));
+        $this->jobHandlerMock->expects($this->at(0))->method('isValidJob')->willReturn(true);
+        $this->jobHandlerMock->expects($this->at(1))->method('isValidJob')->willReturn(false);
+        $this->jobHandlerMock->expects($this->at(2))->method('isValidJob')->willReturn(true);
+        $this->jobHandlerMock->expects($this->at(3))->method('isValidJob')->willReturn(true);
+        $this->jobHandlerMock->expects($this->at(4))->method('isValidJob')->willReturn(true);
+
         $this->queueWorkerSpy = new QueueWorkerSpy($this->sourceQueueMock, $this->jobHandlerMock);
         $this->queueWorkerSpy->setMaxIterations(5);
         $this->queueWorkerSpy->start();
         $this->assertEquals(5, $this->queueWorkerSpy->getIterations());
-        $this->assertEquals(3, $this->sourceQueueMock->successfulCounter, 'Successful counter');
+        $this->assertEquals(2, $this->sourceQueueMock->successfulCounter, 'Successful counter');
         $this->assertEquals(0, $this->sourceQueueMock->failedCounter, 'Failed counter');
         $this->assertEquals(0, $this->sourceQueueMock->errorCounter, 'Error counter');
-        $this->assertEquals(2, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
+        $this->assertEquals(3, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
         $this->assertEquals(6, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }

--- a/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
+++ b/tests/Simpleue/Unitary/Worker/QueueWorkerTest.php
@@ -44,7 +44,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(0, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(20, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(30, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testStopInstruction() {
@@ -62,7 +62,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(0, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(1, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(5, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(8, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testNothingToDo() {
@@ -73,10 +73,10 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->sourceQueueMock->expects($this->at(3))->method('getNext')->willReturn(0);
         $this->sourceQueueMock->expects($this->at(4))->method('getNext')->willReturn('');
 
-        $this->jobHandlerMock = $this->getMock('Simpleue\Mocks\JobSpy', array('isValidJob'));
-        $this->jobHandlerMock->expects($this->at(0))->method('isValidJob')->willReturn(true);
-        $this->jobHandlerMock->expects($this->at(1))->method('isValidJob')->willReturn(false);
-        $this->jobHandlerMock->expects($this->at(2))->method('isValidJob')->willReturn(true);
+        $this->jobHandlerMock = $this->getMock('Simpleue\Mocks\JobSpy', array('isMyJob'));
+        $this->jobHandlerMock->expects($this->at(0))->method('isMyJob')->willReturn(true);
+        $this->jobHandlerMock->expects($this->at(1))->method('isMyJob')->willReturn(false);
+        $this->jobHandlerMock->expects($this->at(2))->method('isMyJob')->willReturn(true);
 
         $this->queueWorkerSpy = new QueueWorkerSpy($this->sourceQueueMock, $this->jobHandlerMock);
         $this->queueWorkerSpy->setMaxIterations(5);
@@ -87,7 +87,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(3, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(4, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(7, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testRunManagedFailedJobs() {
@@ -107,7 +107,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(0, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(10, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(15, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testHandlerManageExceptions() {
@@ -126,7 +126,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(0, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(8, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(12, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testSourceQueueGetNextExceptions() {
@@ -144,7 +144,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(0, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management');
-        $this->assertEquals(2, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(3, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testSourceQueueSuccessfulAndFailedExceptions() {
@@ -166,7 +166,7 @@ class QueueWorkerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $this->sourceQueueMock->errorCounter, 'Error counter');
         $this->assertEquals(0, $this->sourceQueueMock->nothingToDoCounter, 'Nothing to do counter');
         $this->assertEquals(0, $this->sourceQueueMock->stoppedCounter, 'Stop inst. management counter');
-        $this->assertEquals(8, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
+        $this->assertEquals(12, $this->sourceQueueMock->getMessageBodyCounter, 'Message body counter');
     }
 
     public function testWorkerExitsGracefullyOnSigINT() {


### PR DESCRIPTION
At project , we have different job types ( each has Job implemented class ) and we have one AWS SQS queue. If job is not for this job worker, message should return to queue ( nothingToDo )